### PR TITLE
Add Coverage to Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,10 @@ CFLAGS := -std=c99 \
 		  -I$(SRC_PATH) \
 		  -I$(TEST_PATH)
 CFLAGS += -g
-LDFLAGS :=
+TEST_CFLAGS = $(CFLAGS) \
+			  -fprofile-arcs \
+			  -ftest-coverage
+LDFLAGS := -fprofile-generate
 ARFLAGS := r
 
 # Commands
@@ -90,17 +93,17 @@ clean:
 $(OBJ_PATH)/%.o: */%.c
 	$(E)C Compiling $< to $@
 	$(Q)mkdir -p `dirname $@`
-	$(Q)$(COMPILE) -o $@ $< $(CFLAGS)
+	$(Q)$(COMPILE) -o $@ $< $(TEST_CFLAGS)
 
 $(OBJ_PATH)/%.o: $(UNITY_PATH)/%.c
 	$(E)C Compiling $< to $@
 	$(Q)mkdir -p `dirname $@`
-	$(Q)$(COMPILE) -o $@ $< $(CFLAGS)
+	$(Q)$(COMPILE) -o $@ $< $(TEST_CFLAGS)
 
 $(OBJ_PATH)/%.o: $(CMOCK_PATH)/%.c
 	$(E)C Compiling $< to $@
 	$(Q)mkdir -p `dirname $@`
-	$(Q)$(COMPILE) -o $@ $< $(CFLAGS)
+	$(Q)$(COMPILE) -o $@ $< $(TEST_CFLAGS)
 
 $(PROJECT_LIB): $(OBJ)
 	$(Q)$(AR) $(ARFLAGS) $@ $^

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,6 @@ CFLAGS := $(BASE_CFLAGS) \
 		  -I$(UNITY_PATH)/extras/fixture/src \
 		  -I$(CMOCK_PATH)/src \
 		  -I$(TEST_PATH) \
-		  -I$(SRC_PATH) \
 		  -I$(TEST_PATH)/config
 CFLAGS += -g -DUNITY_INCLUDE_CONFIG_H=tests/config/unity_config.h
 TEST_CFLAGS = $(CFLAGS) --coverage


### PR DESCRIPTION
Add coverage to tests. Useful resources include:
- http://www.drdobbs.com/code-coverage-for-c-unit-tests/184401989
- https://qiaomuf.wordpress.com/2011/05/26/use-gcov-and-lcov-to-know-your-test-coverage/
- https://github.com/linux-test-project/lcov
